### PR TITLE
Update country-tld.txt

### DIFF
--- a/country-tld.txt
+++ b/country-tld.txt
@@ -216,7 +216,7 @@ Sint Maarten| .an
 Slovakia| .sk
 Slovenia| .si
 Solomon Islands| .sb
-Somaliland| .so
+Somalia| .so
 South Africa| .za
 South Georgia and the South Sandwich Islands| .gs
 South Korea| .kr


### PR DESCRIPTION
.so domain belongs to Somalia and Somaliland is member of the federal state of Somalia